### PR TITLE
Change Google Java format version to dynamic

### DIFF
--- a/format-code.sh
+++ b/format-code.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
+GJF_VERSION=1.9
 mkdir -p .cache
 cd .cache
-if [ ! -f google-java-format-1.9-all-deps.jar ]
+if [ ! -f google-java-format-$GJF_VERSION-all-deps.jar ]
 then
-    curl -LJO "https://github.com/google/google-java-format/releases/download/google-java-format-1.9/google-java-format-1.9-all-deps.jar"
-    chmod 755 google-java-format-1.9-all-deps.jar
+    curl -LJO "https://github.com/google/google-java-format/releases/download/google-java-format-$GJF_VERSION/google-java-format-$GJF_VERSION-all-deps.jar"
 fi
 cd ..
 
 changed_java_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*java$" )
 echo $changed_java_files
-java -jar .cache/google-java-format-1.9-all-deps.jar --replace $changed_java_files
+java -jar .cache/google-java-format-$GJF_VERSION-all-deps.jar --replace $changed_java_files


### PR DESCRIPTION
## Why

- Easier to maintain

## What 
- Add `GJF_VERSION` so that the version can be updated easily
